### PR TITLE
hide metadata icon and fix array formatting issue in metadata block on indiv item pages

### DIFF
--- a/_includes/item_metadata.html
+++ b/_includes/item_metadata.html
@@ -21,6 +21,12 @@
       {% endif %}
     {% endif %}
       <dt>{{ item.label }}</dt>
-      <dd>{{ value | strip }}</dd>
+      {% if value.first %}
+          {% for v in value %} 
+            <dd>{{ v | strip }}</dd>
+          {% endfor %}
+      {% else %}
+        <dd>{{ value | strip }}</dd>
+      {% endif %}
   {% endfor %}
 </dl>

--- a/_layouts/indiv_examples_datasets.html
+++ b/_layouts/indiv_examples_datasets.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 {% comment %}
-  The block below controls the image viewer
+  The block below controls the image viewer. Note this is currently disabled in code.
 {% endcomment %}
 
 <h3 alt="{{ page.label }}" class='item-label'>{{ page.label }}</h3>
@@ -13,6 +13,12 @@ layout: default
 {% elsif layout.image_viewer %}
   {% assign viewer = layout.image_viewer %}
 {% endif %}
+
+{% comment %}
+  Disable viewer.
+{% endcomment %}
+
+{% assign viewer = False %}
 
 {% if viewer %}
 


### PR DESCRIPTION
as per #82 